### PR TITLE
Allow setting of EC2 private key location via ec2_private_key_file

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repo provides some ansible to bring up an Origin cluster of the specified v
   * For EC2 you will want to set the following environment variables for authentication:
     * AWS_ACCESS_KEY_ID
     * AWS_SECRET_ACCESS_KEY
-  * For EC2 you'll also want to make sure your public key exists at `~/.ssh/${ec2_key}.pem`
+  * For EC2 ensure your private key exists at the location referenced by ec2_private_key_file in config.yml
   * Run `ansible-playbook deploy.yml`
 
 ## Instance cleanup

--- a/ansible/roles/ec2_configure/handlers/main.yml
+++ b/ansible/roles/ec2_configure/handlers/main.yml
@@ -2,4 +2,4 @@
   debug:
     msg:
     - "To ssh into your EC2 VM"
-    -  "ssh -i ~/.ssh/{{ ec2_key }}.pem {{ ansible_user }}@{{ inventory_hostname }}"
+    -  "ssh -i {{ ec2_private_key_file }} {{ ansible_user }}@{{ inventory_hostname }}"

--- a/ansible/roles/ec2_provision/tasks/main.yml
+++ b/ansible/roles/ec2_provision/tasks/main.yml
@@ -132,7 +132,7 @@
   add_host:
     hostname: "{{ ec2_instance.instances[0].public_ip }}"
     ansible_user: ec2-user
-    ansible_ssh_private_key_file: "~/.ssh/{{ ec2_key }}.pem"
+    ansible_ssh_private_key_file: "{{ ec2_private_key_file }}"
 
 - name: Wait for SSH to be available on instance
   wait_for:

--- a/config.yml.example
+++ b/config.yml.example
@@ -8,6 +8,7 @@ ec2_install: true
 ec2_ami: ami-011b3ccf1bd6db744
 ec2_instance_type: m4.large
 ec2_key: libra
+ec2_private_key_file: ~/.ssh/libra.pem
 ec2_region: us-east-1
 ec2_subnet_cidr: 10.0.1.0/24
 ec2_vpc_cidr: 10.0.0.0/16


### PR DESCRIPTION
Allow freedom in where the EC2 private key file is located, example assumes home directory but should help Jenkins or other uses where this is necessary.