### PR TITLE
EC2 allow ability to skip copr repo creation and minor ssh homedir fix

### DIFF
--- a/ansible/roles/ec2_provision/defaults/main.yml
+++ b/ansible/roles/ec2_provision/defaults/main.yml
@@ -1,5 +1,6 @@
 ec2_key: libra
 ec2_private_key_file: ~/.ssh/{{ ec2_key }}.pem
+ec2_repo_create: true
 ec2_instance_type: m4.medium
 ec2_rhel_version: 7.6
 ec2_region: us-east-1

--- a/ansible/roles/ec2_provision/tasks/main.yml
+++ b/ansible/roles/ec2_provision/tasks/main.yml
@@ -29,6 +29,7 @@
   - ansible_os_family == "RedHat"
   - python == "python"
   - not(ansible_distribution == 'Fedora')
+  - ec2_repo_create
 
 - name: Install boto and boto3 through yum/dnf
   package:
@@ -38,7 +39,9 @@
     - "{{ python }}-boto3"
     state: latest
   become: 'true'
-  when: ansible_os_family == "RedHat"
+  when:
+  - ansible_os_family == "RedHat"
+  - ec2_repo_create
 
 - name: Create VPC
   ec2_vpc_net:
@@ -164,6 +167,12 @@
     search_regex: OpenSSH
     delay: 10
     timeout: 300
+
+- name: Ensure SSH homedir is present
+  file:
+    path: "~/.ssh"
+    state: directory
+    mode: 0700
 
 - name: Add SSH key to known hosts
   shell: "ssh-keyscan {{ ec2_instance.instances[0].public_ip }} >> ~/.ssh/known_hosts"

--- a/config.yml.example
+++ b/config.yml.example
@@ -4,7 +4,6 @@ openshift_setup_user: admin
 openshift_setup_user_password: admin
 
 ec2_install: true
-ec2_repo_create: true
 
 ec2_instance_type: m4.large
 ec2_key: libra

--- a/config.yml.example
+++ b/config.yml.example
@@ -4,6 +4,7 @@ openshift_setup_user: admin
 openshift_setup_user_password: admin
 
 ec2_install: true
+ec2_repo_create: true
 
 ec2_instance_type: m4.large
 ec2_key: libra


### PR DESCRIPTION
This allows for a Jenkins use case where user jenkins is not allowed to manipulate masters/slaves for repo or package installations. By default, the boolean is set to true.

The ssh homedir fix is a safety check, based on this error when ssh homedir is not yet present on the system : 
```
TASK [ec2_provision : Add SSH key to known hosts] ******************************
fatal: [localhost]: FAILED! => changed=true 
  cmd: ssh-keyscan 54.88.158.42 >> ~/.ssh/known_hosts
  delta: '0:00:00.003826'
  end: '2019-02-21 15:03:06.703382'
  msg: non-zero return code
  rc: 1
  start: '2019-02-21 15:03:06.699556'
  stderr: '/bin/sh: /var/lib/jenkins/.ssh/known_hosts: No such file or directory'
  stderr_lines:
  - '/bin/sh: /var/lib/jenkins/.ssh/known_hosts: No such file or directory'
  stdout: ''
  stdout_lines: <omitted>
```

- Use ec2_repo_create to decide creation of copr repo and install of boto pkgs (on by default)
- Ensure ssh homedir is actually present before attempting to manipulate known_hosts