### PR TITLE
Add support for terminating local cluster and cleaning up tmpfs mounts

### DIFF
--- a/ansible/local_terminate.yml
+++ b/ansible/local_terminate.yml
@@ -1,0 +1,15 @@
+- hosts: localhost
+  vars_files:
+  - config.yml
+  tasks:
+  - pause:
+      prompt: "Do you want to terminate local cluster? (yes/no)"
+    register: proceed
+
+  - name: Stop local cluster
+    shell: "oc cluster down"
+    when: proceed.user_input == "yes"
+
+  - name: Clean up cluster mounts
+    shell: for i in $(mount | grep openshift | awk '{ print $3}'); do umount "$i"; done && rm -rf /tmp/openshift.local.clusterup
+    when: proceed.user_input == "yes"

--- a/terminate.yml
+++ b/terminate.yml
@@ -2,4 +2,8 @@
   vars_files:
   - config.yml
 
+- import_playbook: ansible/local_terminate.yml
+  when: not(ec2_install)
+
 - import_playbook: ansible/ec2_terminate.yml
+  when: ec2_install


### PR DESCRIPTION
Expand `ansible-playbook terminate.yml` to cover locally installed use.