### PR TITLE
EC2 allow termination of instances without prompting

### DIFF
--- a/ansible/ec2_terminate.yml
+++ b/ansible/ec2_terminate.yml
@@ -24,10 +24,12 @@
   - pause:
       prompt: "Do you want to terminate the instances listed above? (yes/no)"
     register: proceed
+    when: not ec2_force_terminate_instances
 
   - local_action:
       module: ec2
       instance_ids: "{{ instances }}"
       state: absent
       region: "{{ ec2_region }}"
-    when: proceed.user_input == "yes"
+    when: (proceed.user_input is defined and proceed.user_input == "yes") or 
+          ec2_force_terminate_instances == "true"

--- a/config.yml.example
+++ b/config.yml.example
@@ -4,6 +4,7 @@ openshift_setup_user: admin
 openshift_setup_user_password: admin
 
 ec2_install: true
+ec2_force_terminate_instances: false
 
 ec2_instance_type: m4.large
 ec2_key: libra


### PR DESCRIPTION
- Use ec2_force_terminate_instances to proceed without prompting (by default disabled)
- ec2_force_terminate_instances declared in config.yml since ansible/ec2_terminate.yml is not part of a role
- Helps use cases where cleanup of instances needs to be automated