### PR TITLE
Allow ability to auto login remotely to deployed OCP

### DIFF
--- a/ansible/roles/openshift_setup/defaults/main.yml
+++ b/ansible/roles/openshift_setup/defaults/main.yml
@@ -60,3 +60,4 @@ openshift_setup_use_local_oc_client: false
 openshift_setup_vol_mnt_point: "{{ openshift_setup_base_dir }}/openshift.local.pv"
 openshift_setup_user: admin
 openshift_setup_user_password: admin
+openshift_setup_remote_auto_login: false

--- a/ansible/roles/openshift_setup/tasks/main.yml
+++ b/ansible/roles/openshift_setup/tasks/main.yml
@@ -374,3 +374,8 @@
   - name: Login as {{ openshift_setup_user }}
     shell: "{{ openshift_setup_client_oc_cmd }} login -u {{ openshift_setup_user }} -p {{ openshift_setup_user_password }} --insecure-skip-tls-verify=true"
     notify: cluster-info
+
+  - name: Auto login remotely as {{ openshift_setup_user }}
+    shell: "oc login -u {{ openshift_setup_user }} -p {{ openshift_setup_user_password }} https://{{ openshift_setup_hostname }}:8443 --insecure-skip-tls-verify=true"
+    when: openshift_setup_remote_auto_login
+    delegate_to: localhost


### PR DESCRIPTION
- Jenkins use case, disabled by default
- Usage openshift_setup_remote_auto_login=true/false