### PR TITLE
Add nfs-utils to default installation

### DIFF
--- a/ansible/roles/openshift_setup/tasks/main.yml
+++ b/ansible/roles/openshift_setup/tasks/main.yml
@@ -134,6 +134,7 @@
       - "{{ python }}-passlib"
       - tar
       - unzip
+      - nfs-utils
       state: installed
     become: 'true'
     when: ansible_os_family == "RedHat"


### PR DESCRIPTION
- Add nfs-utils to allow NFS backed PVs to work by default on origin3-dev deployments